### PR TITLE
Use RBAC authorization for kubelet API

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Vagrant configuration and scripts for a Kubernetes setup, the hard way.
 The setup follows https://github.com/kelseyhightower/kubernetes-the-hard-way
 with the following exceptions:
 
+* `cri-o` is used as a container runtime, not `cri-containerd`
 * No highly available controllers yet. While 3 controller nodes are setup,
   only the first (`controller-0` / `192.168.199.10`) is used as an
   endpoint.
@@ -122,6 +123,12 @@ etcd-1               Healthy   {"health": "true"}
 etcd-2               Healthy   {"health": "true"}
 etcd-0               Healthy   {"health": "true"}
 [...]
+```
+
+Create `ClusterRole`'s for kubelet API auth:
+
+```
+./scripts/setup-kubelet-api-cluster-role
 ```
 
 Setup the worker binaries, services and configuration:

--- a/config/worker-0-kubelet.service
+++ b/config/worker-0-kubelet.service
@@ -6,12 +6,14 @@ Requires=crio.service
 
 [Service]
 ExecStart=/usr/local/bin/kubelet \
+  --anonymous-auth=false \
+  --authorization-mode=Webhook \
+  --client-ca-file=/var/lib/kubernetes/ca.pem \
   --allow-privileged=true \
   --cluster-dns=10.32.0.10 \
   --cluster-domain=cluster.local \
   --container-runtime=remote \
   --container-runtime-endpoint=unix:///var/run/crio.sock \
-  --enable-custom-metrics \
   --image-pull-progress-deadline=2m \
   --image-service-endpoint=unix:///var/run/crio.sock \
   --kubeconfig=/var/lib/kubelet/kubeconfig \

--- a/config/worker-1-kubelet.service
+++ b/config/worker-1-kubelet.service
@@ -6,12 +6,14 @@ Requires=crio.service
 
 [Service]
 ExecStart=/usr/local/bin/kubelet \
+  --anonymous-auth=false \
+  --authorization-mode=Webhook \
+  --client-ca-file=/var/lib/kubernetes/ca.pem \
   --allow-privileged=true \
   --cluster-dns=10.32.0.10 \
   --cluster-domain=cluster.local \
   --container-runtime=remote \
   --container-runtime-endpoint=unix:///var/run/crio.sock \
-  --enable-custom-metrics \
   --image-pull-progress-deadline=2m \
   --image-service-endpoint=unix:///var/run/crio.sock \
   --kubeconfig=/var/lib/kubelet/kubeconfig \

--- a/config/worker-2-kubelet.service
+++ b/config/worker-2-kubelet.service
@@ -6,12 +6,14 @@ Requires=crio.service
 
 [Service]
 ExecStart=/usr/local/bin/kubelet \
+  --anonymous-auth=false \
+  --authorization-mode=Webhook \
+  --client-ca-file=/var/lib/kubernetes/ca.pem \
   --allow-privileged=true \
   --cluster-dns=10.32.0.10 \
   --cluster-domain=cluster.local \
   --container-runtime=remote \
   --container-runtime-endpoint=unix:///var/run/crio.sock \
-  --enable-custom-metrics \
   --image-pull-progress-deadline=2m \
   --image-service-endpoint=unix:///var/run/crio.sock \
   --kubeconfig=/var/lib/kubelet/kubeconfig \

--- a/scripts/generate-apiserver-service-file
+++ b/scripts/generate-apiserver-service-file
@@ -12,7 +12,7 @@ Documentation=https://github.com/GoogleCloudPlatform/kubernetes
 
 [Service]
 ExecStart=/usr/local/bin/kube-apiserver \\
-  --admission-control=NamespaceLifecycle,NodeRestriction,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota \\
+  --admission-control=Initializers,NamespaceLifecycle,NodeRestriction,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota \\
   --advertise-address=192.168.199.1${i} \\
   --allow-privileged=true \\
   --apiserver-count=3 \\
@@ -35,7 +35,7 @@ ExecStart=/usr/local/bin/kube-apiserver \\
   --kubelet-client-certificate=/var/lib/kubernetes/kubernetes.pem \\
   --kubelet-client-key=/var/lib/kubernetes/kubernetes-key.pem \\
   --kubelet-https=true \\
-  --runtime-config=rbac.authorization.k8s.io/v1alpha1 \\
+  --runtime-config=api/all \\
   --service-account-key-file=/var/lib/kubernetes/ca-key.pem \\
   --service-cluster-ip-range=10.32.0.0/24 \\
   --service-node-port-range=30000-32767 \\

--- a/scripts/generate-kubelet-service-file
+++ b/scripts/generate-kubelet-service-file
@@ -14,12 +14,14 @@ Requires=crio.service
 
 [Service]
 ExecStart=/usr/local/bin/kubelet \\
+  --anonymous-auth=false \\
+  --authorization-mode=Webhook \\
+  --client-ca-file=/var/lib/kubernetes/ca.pem \\
   --allow-privileged=true \\
   --cluster-dns=10.32.0.10 \\
   --cluster-domain=cluster.local \\
   --container-runtime=remote \\
   --container-runtime-endpoint=unix:///var/run/crio.sock \\
-  --enable-custom-metrics \\
   --image-pull-progress-deadline=2m \\
   --image-service-endpoint=unix:///var/run/crio.sock \\
   --kubeconfig=/var/lib/kubelet/kubeconfig \\

--- a/scripts/setup
+++ b/scripts/setup
@@ -15,6 +15,7 @@ vagrant up
 ./scripts/generate-kubeconfig-worker
 ./scripts/setup-etcd
 ./scripts/setup-controller-services
+./scripts/setup-kubelet-api-cluster-role
 ./scripts/setup-worker-services
 ./scripts/configure-kubectl-on-host
 echo -e "\033[1mFinished. Cluster should be healthy and soon in state ready:\033[0m"

--- a/scripts/setup-kubelet-api-cluster-role
+++ b/scripts/setup-kubelet-api-cluster-role
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+set -euo pipefail
+
+readonly dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+pushd "${dir}/../"
+trap 'popd' EXIT
+
+cat <<'EOF' | vagrant ssh "controller-0" -- kubectl apply -f -
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  labels:
+    kubernetes.io/bootstrapping: rbac-defaults
+  name: system:kube-apiserver-to-kubelet
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/proxy
+      - nodes/stats
+      - nodes/log
+      - nodes/spec
+      - nodes/metrics
+    verbs:
+      - "*"
+EOF
+
+cat <<'EOF' | vagrant ssh "controller-0" -- kubectl apply -f -
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: system:kube-apiserver
+  namespace: ""
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:kube-apiserver-to-kubelet
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: User
+    name: kubernetes
+EOF

--- a/scripts/versions.bash
+++ b/scripts/versions.bash
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 readonly k8s_version="v1.8.0"
-readonly etcd_version="v3.2.7"
+readonly etcd_version="v3.2.9"
 readonly cfssl_version="R1.2"


### PR DESCRIPTION
https://github.com/kelseyhightower/kubernetes-the-hard-way switched to
RBAC authorization for apiserver -> kubelet communication in the latest
version. Do the same here.

Also, update the README to reflect the current differences to the KTHW
guide.

Also, remove an obsolet kubelet cli flag `--enable-custom-metrics`.
kubernetes/kubernetes#52564

Finally, update etcd to the latest release.