### PR TITLE
Use HA proxy for highly available controller nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,11 @@ The setup follows https://github.com/kelseyhightower/kubernetes-the-hard-way
 with the following exceptions:
 
 * `cri-o` is used as a container runtime, not `cri-containerd`
-* No highly available controllers yet. While 3 controller nodes are setup,
-  only the first (`controller-0` / `192.168.199.10`) is used as an
-  endpoint.
 * The `pod-cidr` is `10.2${i}.0.0/16`, routes are provisioned from
   `scripts/vagrant-setup-routes.bash` automatically
 * For `crio`, an explicit `--stream-address` must be set, as the address
   of the default interface isn't routable (see e.g. [`config/worker-0-crio.service`](config/worker-0-crio.service))
+* `192.168.199.40` is the IP of the loadbalancer (haproxy) for HA controllers
 
 ## Requirements Host
 
@@ -223,7 +221,3 @@ curl nginx.kthw
 <!DOCTYPE html>
 [...]
 ```
-
-## Todos
-
-* [ ] Add setup of a frontend loadbalancer and use it for HA controllers

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,6 +8,18 @@ Vagrant.configure("2") do |config|
     vb.memory = "512"
   end
 
+  # must be at the top
+  config.vm.define "lb-0" do |c|
+      c.vm.hostname = "lb-0"
+      c.vm.network "private_network", ip: "192.168.199.40"
+
+      c.vm.provision :shell, :path => "scripts/vagrant-setup-haproxy.bash"
+
+      c.vm.provider "virtualbox" do |vb|
+        vb.memory = "256"
+      end
+  end
+
   (0..2).each do |n|
     config.vm.define "controller-#{n}" do |c|
         c.vm.hostname = "controller-#{n}"

--- a/scripts/configure-kubectl-on-host
+++ b/scripts/configure-kubectl-on-host
@@ -7,7 +7,7 @@ readonly dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 kubectl config set-cluster kubernetes-the-hard-way \
   --certificate-authority="${dir}/../certificates/ca.pem" \
   --embed-certs=true \
-  --server=https://192.168.199.10:6443
+  --server=https://192.168.199.40:6443
 
 kubectl config set-credentials admin \
   --client-certificate="${dir}/../certificates/admin.pem" \

--- a/scripts/generate-kubeconfig-worker
+++ b/scripts/generate-kubeconfig-worker
@@ -8,7 +8,7 @@ for instance in worker-0 worker-1 worker-2; do
   kubectl config set-cluster kubernetes-the-hard-way \
     --certificate-authority="${dir}/../certificates/ca.pem" \
     --embed-certs=true \
-    --server=https://192.168.199.10:6443 \
+    --server=https://192.168.199.40:6443 \
     --kubeconfig="${dir}/../config/${instance}.kubeconfig"
 
   kubectl config set-credentials system:node:${instance} \

--- a/scripts/generate-kubernetes-cert
+++ b/scripts/generate-kubernetes-cert
@@ -11,6 +11,6 @@ cfssl gencert \
   -ca=ca.pem \
   -ca-key=ca-key.pem \
   -config=ca-config.json \
-  -hostname=10.32.0.1,192.168.199.10,192.168.199.11,192.168.199.12,127.0.0.1,kubernetes.default \
+  -hostname=10.32.0.1,192.168.199.40,192.168.199.10,192.168.199.11,192.168.199.12,127.0.0.1,kubernetes.default \
   -profile=kubernetes \
   kubernetes-csr.json | cfssljson -bare kubernetes

--- a/scripts/setup-traefik
+++ b/scripts/setup-traefik
@@ -69,7 +69,7 @@ cat >/etc/traefik.toml <<TRAEFIK_CONFIG
 logLevel = "INFO"
 
 [kubernetes]
-endpoint = "https://192.168.199.10:6443"
+endpoint = "https://192.168.199.40:6443"
 token = "$(kubectl --namespace kube-system get secrets $(kubectl --namespace kube-system get serviceaccount traefik -o jsonpath='{.secrets[].name}') -o jsonpath='{.data.token}' | base64 -d)"
 certAuthFilePath = "/etc/kubernetes/ca.pem"
 

--- a/scripts/vagrant-setup-haproxy.bash
+++ b/scripts/vagrant-setup-haproxy.bash
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+set -euo pipefail
+
+apt-get update
+apt-get install -y haproxy
+
+cat >/etc/haproxy/haproxy.cfg <<EOF
+
+global
+	log /dev/log	local0
+	log /dev/log	local1 notice
+	chroot /var/lib/haproxy
+	stats socket /run/haproxy/admin.sock mode 660 level admin
+	stats timeout 30s
+	user haproxy
+	group haproxy
+	daemon
+
+	# Default SSL material locations
+	ca-base /etc/ssl/certs
+	crt-base /etc/ssl/private
+
+	# Default ciphers to use on SSL-enabled listening sockets.
+	# For more information, see ciphers(1SSL). This list is from:
+	#  https://hynek.me/articles/hardening-your-web-servers-ssl-ciphers/
+	ssl-default-bind-ciphers ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:ECDH+3DES:DH+3DES:RSA+AESGCM:RSA+AES:RSA+3DES:!aNULL:!MD5:!DSS
+	ssl-default-bind-options no-sslv3
+
+defaults
+	log	global
+	mode	tcp
+	option	tcplog
+	option	dontlognull
+        timeout connect 5000
+        timeout client  50000
+        timeout server  50000
+	errorfile 400 /etc/haproxy/errors/400.http
+	errorfile 403 /etc/haproxy/errors/403.http
+	errorfile 408 /etc/haproxy/errors/408.http
+	errorfile 500 /etc/haproxy/errors/500.http
+	errorfile 502 /etc/haproxy/errors/502.http
+	errorfile 503 /etc/haproxy/errors/503.http
+	errorfile 504 /etc/haproxy/errors/504.http
+
+frontend k8s
+	bind 192.168.199.40:6443
+	default_backend k8s_backend
+
+backend k8s_backend
+	balance roundrobin
+	mode tcp
+	server controller-0 192.168.199.10:6443 check inter 1000
+	server controller-1 192.168.199.11:6443 check inter 1000
+	server controller-2 192.168.199.12:6443 check inter 1000
+EOF
+
+systemctl restart haproxy


### PR DESCRIPTION
192.168.199.40 is the HA endpoint for the k8s cluster which should be
used now.