### PR TITLE
Update crio v1.0.0-beta.0 -> crio-amd64-v1.0.2

### DIFF
--- a/config/worker-0-crio.service
+++ b/config/worker-0-crio.service
@@ -3,7 +3,7 @@ Description=CRI-O daemon
 Documentation=https://github.com/kubernetes-incubator/cri-o
 
 [Service]
-ExecStart=/usr/local/bin/crio --stream-address 192.168.199.20
+ExecStart=/usr/local/bin/crio --stream-address 192.168.199.20 --runtime /usr/local/bin/runc
 Restart=always
 RestartSec=10s
 

--- a/config/worker-1-crio.service
+++ b/config/worker-1-crio.service
@@ -3,7 +3,7 @@ Description=CRI-O daemon
 Documentation=https://github.com/kubernetes-incubator/cri-o
 
 [Service]
-ExecStart=/usr/local/bin/crio --stream-address 192.168.199.21
+ExecStart=/usr/local/bin/crio --stream-address 192.168.199.21 --runtime /usr/local/bin/runc
 Restart=always
 RestartSec=10s
 

--- a/config/worker-2-crio.service
+++ b/config/worker-2-crio.service
@@ -3,7 +3,7 @@ Description=CRI-O daemon
 Documentation=https://github.com/kubernetes-incubator/cri-o
 
 [Service]
-ExecStart=/usr/local/bin/crio --stream-address 192.168.199.22
+ExecStart=/usr/local/bin/crio --stream-address 192.168.199.22 --runtime /usr/local/bin/runc
 Restart=always
 RestartSec=10s
 

--- a/scripts/download-tools
+++ b/scripts/download-tools
@@ -29,9 +29,9 @@ tar -xf "etcd-${etcd_version}-linux-amd64.tar.gz"
 curl -sSL \
   -O "https://github.com/containernetworking/plugins/releases/download/v0.6.0/cni-plugins-amd64-v0.6.0.tgz" \
   -O "https://github.com/opencontainers/runc/releases/download/v1.0.0-rc4/runc.amd64" \
-  -O "https://storage.googleapis.com/kubernetes-the-hard-way/crio-amd64-v1.0.0-beta.0.tar.gz"
+  -O "https://files.schu.io/pub/cri-o/crio-amd64-v1.0.2.tar.gz"
 
-tar -xf crio-amd64-v1.0.0-beta.0.tar.gz
+tar -xf crio-amd64-v1.0.2.tar.gz
 
 mv runc.amd64 runc
 

--- a/scripts/generate-crio-service-file
+++ b/scripts/generate-crio-service-file
@@ -11,7 +11,7 @@ Description=CRI-O daemon
 Documentation=https://github.com/kubernetes-incubator/cri-o
 
 [Service]
-ExecStart=/usr/local/bin/crio --stream-address 192.168.199.2${i}
+ExecStart=/usr/local/bin/crio --stream-address 192.168.199.2${i} --runtime /usr/local/bin/runc
 Restart=always
 RestartSec=10s
 


### PR DESCRIPTION
Since there are no official binaries for download, we have to use a
custom built.