### PR TITLE
define the name of the vm second time

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,6 +17,7 @@ Vagrant.configure("2") do |config|
 
       c.vm.provider "virtualbox" do |vb|
         vb.memory = "256"
+        vb.name = "lb-0"
       end
   end
 
@@ -26,6 +27,9 @@ Vagrant.configure("2") do |config|
         c.vm.network "private_network", ip: "192.168.199.1#{n}"
 
         c.vm.provision :shell, :path => "scripts/vagrant-setup-hosts-file.bash"
+        c.vm.provider "virtualbox" do |vb|
+          vb.name = "controller-#{n}"
+        end
     end
   end
 
@@ -36,6 +40,10 @@ Vagrant.configure("2") do |config|
 
         c.vm.provision :shell, :path => "scripts/vagrant-setup-routes.bash"
         c.vm.provision :shell, :path => "scripts/vagrant-setup-hosts-file.bash"
+
+        c.vm.provider "virtualbox" do |vb|
+          vb.name = "worker-#{n}"
+        end
     end
   end
 
@@ -44,5 +52,8 @@ Vagrant.configure("2") do |config|
       c.vm.network "private_network", ip: "192.168.199.30"
 
       c.vm.provision :shell, :path => "scripts/vagrant-setup-routes.bash"
+      c.vm.provider "virtualbox" do |vb|
+        vb.name = "traefik-0"
+      end
   end
 end


### PR DESCRIPTION
Could be because of my unique combination of vagrant/virtualbox /virtualbox plugin that the VMs don't get created with their names as given in the `config.vm.define`, so I had to explicitly name them using `cfg.vm.provider` block. 

Not too keen on getting this merged, it could be only an issue on my end, but I did say I'll create a PR so here it is.

Thanks for a great meetup/workshop 💯 