### PR TITLE
fix virtual machine name maximum length problem

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,6 +6,7 @@ Vagrant.configure("2") do |config|
 
   config.vm.provider "virtualbox" do |vb|
     vb.memory = "512"
+    vb.customize ["modifyvm", :id, "--audio", "none"]
   end
 
   # must be at the top


### PR DESCRIPTION
Fixes #14 

This issue is also discussed here:

https://github.com/hashicorp/vagrant/issues/9524

The above fix is  mentioned there - still do not know why changing audio settings fixes the length of VM names.