### PR TITLE
Fix issue where nslookup on busybox:latest (Version :1.29) doesn't work.

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ kubectl create -f ./manifests/kube-dns.yaml
 [...]
 kubectl get pods -l k8s-app=kube-dns -n kube-system
 [...]
-kubectl run busybox --image=busybox --command -- sleep 3600
+kubectl run busybox --image=busybox:1.28 --command -- sleep 3600
 [...]
 POD_NAME=$(kubectl get pods -l run=busybox -o jsonpath="{.items[0].metadata.name}")
 kubectl exec -ti $POD_NAME -- nslookup kubernetes

--- a/config/worker-0-kubelet-config
+++ b/config/worker-0-kubelet-config
@@ -13,6 +13,7 @@ clusterDomain: "cluster.local"
 clusterDNS:
 - "10.32.0.10"
 podCIDR: "10.20.0.0/16"
+resolvConf: "/run/systemd/resolve/resolv.conf"
 runtimeRequestTimeout: "10m"
 tlsCertFile: "/var/lib/kubelet/worker-0.pem"
 tlsPrivateKeyFile: "/var/lib/kubelet/worker-0-key.pem"

--- a/config/worker-1-kubelet-config
+++ b/config/worker-1-kubelet-config
@@ -13,6 +13,7 @@ clusterDomain: "cluster.local"
 clusterDNS:
 - "10.32.0.10"
 podCIDR: "10.21.0.0/16"
+resolvConf: "/run/systemd/resolve/resolv.conf"
 runtimeRequestTimeout: "10m"
 tlsCertFile: "/var/lib/kubelet/worker-1.pem"
 tlsPrivateKeyFile: "/var/lib/kubelet/worker-1-key.pem"

--- a/config/worker-2-kubelet-config
+++ b/config/worker-2-kubelet-config
@@ -13,6 +13,7 @@ clusterDomain: "cluster.local"
 clusterDNS:
 - "10.32.0.10"
 podCIDR: "10.22.0.0/16"
+resolvConf: "/run/systemd/resolve/resolv.conf"
 runtimeRequestTimeout: "10m"
 tlsCertFile: "/var/lib/kubelet/worker-2.pem"
 tlsPrivateKeyFile: "/var/lib/kubelet/worker-2-key.pem"

--- a/scripts/generate-kubelet-config-file
+++ b/scripts/generate-kubelet-config-file
@@ -21,6 +21,7 @@ clusterDomain: "cluster.local"
 clusterDNS:
 - "10.32.0.10"
 podCIDR: "10.2${i}.0.0/16"
+resolvConf: "/run/systemd/resolve/resolv.conf"
 runtimeRequestTimeout: "10m"
 tlsCertFile: "/var/lib/kubelet/worker-${i}.pem"
 tlsPrivateKeyFile: "/var/lib/kubelet/worker-${i}-key.pem"


### PR DESCRIPTION
I borrowed some fixes from the upstream project to fix #19 

- Explicitly set resolv.conf for Kubelets on worker nodes
- Pin Busybox to 1.28

```
$ kubectl run busybox --image=busybox:1.28 --command -- sleep 3600
deployment.apps/busybox created
$ POD_NAME=$(kubectl get pods -l run=busybox -o jsonpath="{.items[0].metadata.name}")
$ kubectl exec -ti $POD_NAME -- nslookup kubernetes
Server:    10.32.0.10
Address 1: 10.32.0.10 kube-dns.kube-system.svc.cluster.local

Name:      kubernetes
Address 1: 10.32.0.1 kubernetes.default.svc.cluster.local
$
```