### PR TITLE
FIX: switch base64 -d to base64 --decode

### DIFF
--- a/scripts/setup-traefik
+++ b/scripts/setup-traefik
@@ -70,7 +70,7 @@ logLevel = "INFO"
 
 [kubernetes]
 endpoint = "https://192.168.199.40:6443"
-token = "$(kubectl --namespace kube-system get secrets $(kubectl --namespace kube-system get serviceaccount traefik -o jsonpath='{.secrets[].name}') -o jsonpath='{.data.token}' | base64 -d)"
+token = "$(kubectl --namespace kube-system get secrets $(kubectl --namespace kube-system get serviceaccount traefik -o jsonpath='{.secrets[].name}') -o jsonpath='{.data.token}' | base64 --decode)"
 certAuthFilePath = "/etc/kubernetes/ca.pem"
 
 [accessLog]


### PR DESCRIPTION
base64 -d does not work on MacOSX because it is base64 -D.
Instead base64 --decode work on both platform, so switch to this syntax
makes it more portable