### PR TITLE
Add crictl.yaml to worker nodes

### DIFF
--- a/scripts/setup-worker-services
+++ b/scripts/setup-worker-services
@@ -31,6 +31,7 @@ cp /vagrant/tools/runc /usr/local/bin/
 cp /vagrant/tools/{crio,kube-proxy,kubelet,kubectl} /usr/local/bin/
 cp /vagrant/tools/{conmon,pause} /usr/local/libexec/crio/
 cp /vagrant/tools/{crio.conf,seccomp.json} /etc/crio/
+cp /vagrant/tools/crio.yaml /etc/
 cp /vagrant/tools/policy.json /etc/containers/
 
 cp "/vagrant/config/$(hostname)-10-bridge.conf" /etc/cni/net.d/10-bridge.conf


### PR DESCRIPTION
Withouth this file `crictl` binary won't work. 

Planning to add `crictl` binary in a different PR where i'll bump `cri-o` to 1.12 as per official doc matrix