### PR TITLE
Smoke tests dont't work.

### DIFF
--- a/scripts/setup-traefik
+++ b/scripts/setup-traefik
@@ -11,7 +11,7 @@ vagrant up traefik-0
 
 kubectl --namespace=kube-system create serviceaccount traefik
 
-cat <<EOF | vagrant ssh "controller-0" -- kubectl apply -f -
+cat <<EOF | kubectl apply -f -
 
 ---
 kind: ClusterRole


### PR DESCRIPTION
I was unable to run smoketest.
I have a fix to run smoketest.
However, I do not understand this cause.
If I was doing something wrong, I would appreciate it if you could tell me.
Perhaps something related to issues #29?

# before
```bash
$ vagrant destroy -f
$ ./scripts/setup

$ NODE_PORT=$(kubectl get svc nginx --output=jsonpath='{range .spec.ports[0]}{.nodePort}')
$ for i in {0..2}; do curl -sS 192.168.199.2${i}:${NODE_PORT} | awk '/<h1>/{gsub("<[/]*h1>", ""); print $0}'; done
Welcome to nginx!
Welcome to nginx!
Welcome to nginx!
$ sudo route add -net 10.32.0.0/24 gw 192.168.199.22
$ ./scripts/setup-traefik
[...]
serviceaccount/traefik created
error: Missing or incomplete configuration info.  Please point to an existing, complete config file:

  1. Via the command-line flag --kubeconfig
  2. Via the KUBECONFIG environment variable
  3. In your home directory as ~/.kube/config

To view or setup config directly use the 'config' command.
$ kubectl apply -f ./manifests/nginx-ingress.yaml
$ echo "192.168.199.30 nginx.kthw" | sudo tee -a /etc/hosts
$ curl nginx.kthw
curl: (7) Failed to connect to nginx.kthw port 80: Connection refused
```

# after fix

```bash
$ vagrant destroy -f
$ ./scripts/setup

$ NODE_PORT=$(kubectl get svc nginx --output=jsonpath='{range .spec.ports[0]}{.nodePort}')
$ for i in {0..2}; do curl -sS 192.168.199.2${i}:${NODE_PORT} | awk '/<h1>/{gsub("<[/]*h1>", ""); print $0}'; done
Welcome to nginx!
Welcome to nginx!
Welcome to nginx!
$ sudo route add -net 10.32.0.0/24 gw 192.168.199.22
$ ./scripts/setup-traefik
[...]
serviceaccount/traefik created
clusterrole.rbac.authorization.k8s.io/traefik-ingress-controller created
clusterrolebinding.rbac.authorization.k8s.io/traefik-ingress-controller created
Created symlink /etc/systemd/system/multi-user.target.wants/traefik.service → /etc/systemd/system/traefik.service.
$ kubectl apply -f ./manifests/nginx-ingress.yaml
$ echo "192.168.199.30 nginx.kthw" | sudo tee -a /etc/hosts
$ curl nginx.kthw
<!DOCTYPE html>
[...]
```